### PR TITLE
Initialized Volume dataframe with np.int64 type to avoid integer overflow on Windows

### DIFF
--- a/fix_yahoo_finance/__init__.py
+++ b/fix_yahoo_finance/__init__.py
@@ -79,7 +79,7 @@ def parse_ticker_csv(csv_str, auto_adjust):
 
     df.index = pd.to_datetime(df.index)
     df = df.apply(pd.to_numeric)
-    df['Volume'] = df['Volume'].fillna(0).astype(int)
+    df['Volume'] = df['Volume'].fillna(0).astype(np.int64)
 
     if auto_adjust:
         ratio = df["Close"] / df["Adj Close"]


### PR DESCRIPTION
I believe the Volume dataframes should be initialized explicitly as numpy.int64, because otherwise numpy will inherit the int type from the system's C compiler. This is fine for Unix and Mac systems, but even in 64 bit Windows, C Long is 32 bits. When pulling data for symbols with very large Volume, like ^GSPC (S&P500), negative values end up in the dataframes due to the 32-bit integer overflowing. Initializing as numpy.int64 solves this problem.